### PR TITLE
v2.2.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = '2.2.1' %}
+{% set version = '2.2.0' %}
 
 {% set posix = 'm2-' if win else '' %}
 {% set native = 'm2w64-' if win else '' %}
@@ -12,7 +12,7 @@ source:
   url:
     - https://cran.r-project.org/src/contrib/ggplot2_{{ version }}.tar.gz
     - https://cran.r-project.org/src/contrib/Archive/ggplot2/ggplot2_{{ version }}.tar.gz
-  sha256: 5fbc89fec3160ad14ba90bd545b151c7a2e7baad021c0ab4b950ecd6043a8314
+  sha256: 64d7d9085573b439295bcb58ea4d39ba5d71911dbb501f1e7a30d13740ea2cda
 
 build:
   number: 0
@@ -53,6 +53,7 @@ test:
 about:
   home: http://ggplot2.tidyverse.org, https://github.com/tidyverse/ggplot2
   license: GPL-2
+  license_file: LICENSE
   summary: A system for 'declaratively' creating graphics, based on "The Grammar of Graphics".
     You provide the data, tell 'ggplot2' how to map variables to aesthetics, what graphical
     primitives to use, and it takes care of the details.
@@ -62,3 +63,4 @@ extra:
   recipe-maintainers:
     - johanneskoester
     - bgruening
+    - ocefpaf


### PR DESCRIPTION
I need this version for... Reasons...

we can leave the feedstock as-is after we merge this and updated when a new version comes or re-submit `v2.2.1`. Whatever the current team decides is OK by me. 