### PR TITLE
Add R 3.5.1 builds for ggplot2 v2.2.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = '3.0.0' %}
+{% set version = '2.2.1' %}
 {% set posix = 'm2-' if win else '' %}
 {% set native = 'm2w64-' if win else '' %}
 
@@ -11,7 +11,7 @@ source:
   url:
     - {{ cran_mirror }}/src/contrib/ggplot2_{{ version }}.tar.gz
     - {{ cran_mirror }}/src/contrib/Archive/ggplot2/ggplot2_{{ version }}.tar.gz
-  sha256: c768f5039ef684c3874a92210a975af52e74f00927ff31c31a73eb1fe139694d
+  sha256: 5fbc89fec3160ad14ba90bd545b151c7a2e7baad021c0ab4b950ecd6043a8314
 
 build:
   merge_build_host: True  # [win]
@@ -30,28 +30,20 @@ requirements:
     - r-digest
     - r-gtable >=0.1.1
     - r-lazyeval
-    - r-mgcv
     - r-plyr >=1.7.1
     - r-reshape2
-    - r-rlang
-    - r-scales >=0.5.0
+    - r-scales >=0.4.1
     - r-tibble
-    - r-viridislite
-    - r-withr >=2.0.0
   run:
     - r-base
     - r-mass
     - r-digest
     - r-gtable >=0.1.1
     - r-lazyeval
-    - r-mgcv
     - r-plyr >=1.7.1
     - r-reshape2
-    - r-rlang
-    - r-scales >=0.5.0
+    - r-scales >=0.4.1
     - r-tibble
-    - r-viridislite
-    - r-withr >=2.0.0
 
 test:
   commands:


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
- Build number is 1, because v2.2.1 package already exists
- Should go in a `v2.2.1` branch (not merge into the master branch)
- Needed to get `rpy2` working with R 3.5.1 (https://github.com/conda-forge/rpy2-feedstock/pull/10)